### PR TITLE
improve OverlayService singleton error message

### DIFF
--- a/lib/src/laminate/overlay/overlay_service.dart
+++ b/lib/src/laminate/overlay/overlay_service.dart
@@ -77,7 +77,8 @@ class OverlayService {
       // Overlay service should not be injected if it is already available
       if (existingInstance != null) {
         _logger.severe('OverlayService must be a singleton: '
-            'Check that there is no nested overlayBindings or popupBindings');
+            'Remove nested OverlayService providers such as overlayBindings, '
+            'popupBindings, datepickerBindings or materialProviders');
       }
       return true;
     }());


### PR DESCRIPTION
This error message was subtly misleading to me in that I thought it implied that OverlayService could only be provided by overlayBindings or popupBindings in my code. I changed the wording to suggest that there are other possibilities and added more examples from this library.